### PR TITLE
[RFC] hello: do not require user 1000

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,5 +6,6 @@ RUN gcc -O2 -static -o podman_hello_world podman_hello_world.c
 FROM scratch
 LABEL maintainer="Podman Maintainers"
 LABEL artist="Máirín Ní Ḋuḃṫaiġ, Twitter:@mairin"
+LABEL io.containers.capabilities="sys_chroot"
 COPY --from=builder podman_hello_world /usr/local/bin/podman_hello_world
 CMD ["/usr/local/bin/podman_hello_world"]

--- a/Containerfile
+++ b/Containerfile
@@ -6,6 +6,5 @@ RUN gcc -O2 -static -o podman_hello_world podman_hello_world.c
 FROM scratch
 LABEL maintainer="Podman Maintainers"
 LABEL artist="Máirín Ní Ḋuḃṫaiġ, Twitter:@mairin"
-USER 1000
 COPY --from=builder podman_hello_world /usr/local/bin/podman_hello_world
 CMD ["/usr/local/bin/podman_hello_world"]

--- a/README.md
+++ b/README.md
@@ -53,20 +53,6 @@ podman build -t myhello .
 podman run myhello
 ```
 
-## Potential Issues:
-
-The image runs as a rootless user with the UID set to `1000`.
-If the /etc/subuid and /etch/subgid values are not set appropriately to run as a
-rootless user on the host, an error like this might be raised:
-
-```
-Copying blob acab339ca1e8 done
-ERRO[0002] Error while applying layer: ApplyLayer exit status 1 stdout:  stderr: potentially insufficient UIDs or GIDs available in user namespace (requested 0:12 for /var/spool/mail): Check /etc/subuid and /etc/subgid: lchown /var/spool/mail: invalid argument
-Error: writing blob: adding layer with blob "sha256:ee0cde9de8a68f171a8c03b0e9954abf18576947e2f3187e84d8c31ccd8f6a09": ApplyLayer exit status 1 stdout:  stderr: potentially insufficient UIDs or GIDs available in user namespace (requested 0:12 for /var/spool/mail): Check /etc/subuid and /etc/subgid: lchown /var/spool/mail: invalid argument
-```
-
-Please refer to this [blog post](https://www.redhat.com/sysadmin/rootless-podman) for further configuration information.
-
 ## THANKS!
 
 Many Thanks to [Anders Björklund](https://github.com/afbjorklund) for a great discussion during the


### PR DESCRIPTION
I've tried running the image on a system where rootless users are using a single ID and it failed.
    
While it is a good practice to run as a different user, I think that for such a simple code there is not much gain in running as a different user, so let's just run as root and avoid completely the issue.

To balance on the security side, I've also specified a list of capabilities needed to run the container (more details in the commit message).

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
